### PR TITLE
Add AudioPlaybackEngine; cache sounds

### DIFF
--- a/AudioPlaybackEngine.cs
+++ b/AudioPlaybackEngine.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace JNSoundboard
+{
+    class AudioPlaybackEngine : IDisposable
+    {
+        private readonly IWavePlayer outputDevice;
+        private readonly MixingSampleProvider mixer;
+        private IDictionary<string, CachedSound> cachedSounds = new Dictionary<string, CachedSound>();
+
+        public AudioPlaybackEngine(int sampleRate = 44100, int channelCount = 2)
+        {
+            outputDevice = new WaveOutEvent();
+            mixer = new MixingSampleProvider(WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channelCount));
+            mixer.ReadFully = true;
+            outputDevice.Init(mixer);
+            outputDevice.Play();
+        }
+
+        public void PlaySound(string fileName)
+        {
+            var input = new AudioFileReader(fileName);
+
+            CachedSound cachedSound = null;
+
+            if (!cachedSounds.TryGetValue(fileName, out cachedSound))
+            {
+                cachedSound = new CachedSound(fileName);
+                cachedSounds.Add(fileName, cachedSound);
+            }
+
+            PlaySound(cachedSound);
+        }
+
+        private ISampleProvider ConvertToRightChannelCount(ISampleProvider input)
+        {
+            if (input.WaveFormat.Channels == mixer.WaveFormat.Channels)
+            {
+                return input;
+            }
+            if (input.WaveFormat.Channels == 1 && mixer.WaveFormat.Channels == 2)
+            {
+                return new MonoToStereoSampleProvider(input);
+            }
+            throw new NotImplementedException("Not yet implemented this channel count conversion");
+        }
+
+        public void PlaySound(CachedSound sound)
+        {
+            AddMixerInput(new CachedSoundSampleProvider(sound));
+        }
+
+        private void AddMixerInput(ISampleProvider input)
+        {
+            var resampled = new WdlResamplingSampleProvider(input, mixer.WaveFormat.SampleRate);
+            mixer.AddMixerInput(ConvertToRightChannelCount(resampled));
+        }
+
+        public void Dispose()
+        {
+            outputDevice.Dispose();
+        }
+
+        public static readonly AudioPlaybackEngine Instance = new AudioPlaybackEngine(44100, 2);
+    }
+}

--- a/AudioPlaybackEngine.cs
+++ b/AudioPlaybackEngine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
+using System.Linq;
 
 namespace JNSoundboard
 {
@@ -15,6 +16,19 @@ namespace JNSoundboard
         {
             mixer = new MixingSampleProvider(WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channelCount));
             mixer.ReadFully = true;
+            mixer.MixerInputEnded += OnMixerInputEnded;
+        }
+
+        public event EventHandler AllInputEnded;
+
+        private void OnMixerInputEnded(object sender, SampleProviderEventArgs e)
+        {
+            // check if there are any inputs left
+            // OnMixerInputEnded gets invoked before the corresponding source is removed from the List so there should be exactly one source left
+            if (mixer.MixerInputs.Count() == 1)
+            {
+                AllInputEnded?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         public void Init(int deviceNumber)

--- a/CachedSound.cs
+++ b/CachedSound.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NAudio.Wave;
+
+// https://mark-dot-net.blogspot.de/2014/02/fire-and-forget-audio-playback-with.html
+// Mark Heath 2014
+
+namespace JNSoundboard
+{
+    class CachedSound
+    {
+        public float[] AudioData { get; private set; }
+        public WaveFormat WaveFormat { get; private set; }
+        public CachedSound(string audioFileName)
+        {
+            using (var audioFileReader = new AudioFileReader(audioFileName))
+            {
+                // TODO: could add resampling in here if required
+                WaveFormat = audioFileReader.WaveFormat;
+                var wholeFile = new List<float>((int)(audioFileReader.Length / 4));
+                var readBuffer = new float[audioFileReader.WaveFormat.SampleRate * audioFileReader.WaveFormat.Channels];
+                int samplesRead;
+                while ((samplesRead = audioFileReader.Read(readBuffer, 0, readBuffer.Length)) > 0)
+                {
+                    wholeFile.AddRange(readBuffer.Take(samplesRead));
+                }
+                AudioData = wholeFile.ToArray();
+            }
+        }
+    }
+}

--- a/CachedSoundSampleProvider.cs
+++ b/CachedSoundSampleProvider.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NAudio.Wave;
+
+namespace JNSoundboard
+{
+    class CachedSoundSampleProvider : ISampleProvider
+    {
+        private readonly CachedSound cachedSound;
+        private long position;
+
+        public CachedSoundSampleProvider(CachedSound cachedSound)
+        {
+            this.cachedSound = cachedSound;
+        }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            var availableSamples = cachedSound.AudioData.Length - position;
+            var samplesToCopy = Math.Min(availableSamples, count);
+            Array.Copy(cachedSound.AudioData, position, buffer, offset, samplesToCopy);
+            position += samplesToCopy;
+            return (int)samplesToCopy;
+        }
+
+        public WaveFormat WaveFormat { get { return cachedSound.WaveFormat; } }
+    }
+}

--- a/JNSoundboard.csproj
+++ b/JNSoundboard.csproj
@@ -85,6 +85,9 @@
     <Compile Include="AddEditHotkeyForm.Designer.cs">
       <DependentUpon>AddEditHotkeyForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="AudioPlaybackEngine.cs" />
+    <Compile Include="CachedSound.cs" />
+    <Compile Include="CachedSoundSampleProvider.cs" />
     <Compile Include="Helper.cs" />
     <Compile Include="Keyboard.cs" />
     <Compile Include="XMLSettings.cs" />

--- a/JNSoundboard.csproj
+++ b/JNSoundboard.csproj
@@ -65,8 +65,9 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NAudio">
-      <HintPath>packages\NAudio.1.7.3\lib\net35\NAudio.dll</HintPath>
+    <Reference Include="NAudio, Version=1.8.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\NAudio.1.8.3\lib\net35\NAudio.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -47,6 +47,17 @@ namespace JNSoundboard
             cbLoopbackDevices.SelectedIndexChanged += cbLoopbackDevices_SelectedIndexChanged;
 
             initAudioPlaybackEngine();
+
+            AudioPlaybackEngine.Instance.AllInputEnded += OnAllInputEnded;
+        }
+
+        private void OnAllInputEnded(object sender, EventArgs e)
+        {
+            if (keyUpPushToTalkKey)
+            {
+                keyUpPushToTalkKey = false;
+                Keyboard.sendKey(pushToTalkKey, false);
+            }
         }
 
         private void initAudioPlaybackEngine()

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -181,9 +181,9 @@ namespace JNSoundboard
 
             try
             {
-                playbackWaveOut.Init(new AudioFileReader(file));
-
-                playbackWaveOut.Play();
+                AudioPlaybackEngine.Instance.PlaySound(file);
+                //playbackWaveOut.Init(new AudioFileReader(file));
+                //playbackWaveOut.Play();
             }
             catch (FormatException ex)
             {

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NAudio" version="1.7.3" targetFramework="net46" />
+  <package id="NAudio" version="1.8.3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Fixes memory leak due to not disposing AudioFileReader.

Both AudioFileReader and WaveOut should be disposed after usage.
The Code from https://mark-dot-net.blogspot.de/2014/02/fire-and-forget-audio-playback-with.html fixes that problem and also implements some useful caching.

But due to the use of the MixingSampleProvider all inputs now need to be 'manually' resampled and converted to the right channel count.

I mainly just copy-pasted it all together. This obviously breaks some things like the 'stop all sounds' functionality. But let me know what you think before I do anything more in that direction.